### PR TITLE
Set heat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ Activates or deactivates a circuit. See [`SLSetCircuitStateMessage`](#slsetcircu
 
 Sets the heating setpoint for any body. See [`SLSetHeatSetPointMessage`](#slsetheatsetpointmessage) documentation for argument values. Emits the `setPointChanged` event when response is acknowledged.
 
+### setHeatMode(controllerId, bodyType, heatMode)
+
+Sets the preferred heat mode. See [`SLSetHeatModeMessage`](#slsetheatmodemessage) documentation for argument values. Emits the `heatModeChanged` event when response is acknowledged.
+
 ### sendLightCommand(controllerId, command)
 
 Sends a lighting command. See [`SLLightControlMessage`](#sllightcontrolmessage) documentation for argument values. Emits the `sentLightCommand` event when response is acknowledged.
@@ -379,6 +383,17 @@ Passed as an argument to the emitted `setPointChanged` event. The passed version
   * Note that while `SLControllerConfigMessage` includes a controllerId, this ID, in my experience, should always be 0.
 * `bodyType` - integer indicating the type of body to set the setpoint of. The pool is body `0` and the spa is body `1`.
 * `temperature` - integer indicating the desired setpoint. This is presumably in whatever units your system is set to (celsius or fahrenheit).
+
+## SLSetHeatModeMessage
+
+Passed as an argument to the emitted `setHeatMode` event. The passed version is empty, however, since the response is just an acknowledgement of receipt of the set command.
+
+### Properties
+
+* `controllerId` - integer indicating the ID of the controller to send this command to.
+  * Note that while `SLControllerConfigMessage` includes a controllerId, this ID, in my experience, should always be 0.
+* `bodyType` - integer indicating the type of body to set the setpoint of. The pool is body `0` and the spa is body `1`.
+* `heatMode` - integer indicating the desired heater mode. Valid values are: 0: "Off", 1: "Solar", 2 : "Solar Preferred", 3 : "Heat Pump", 4: "Don't Change"
 
 ## SLLightControlMessage
 

--- a/heatmodetest.js
+++ b/heatmodetest.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const ScreenLogic = require('./index');
+
+// use this to find and connect to units local to the network this is running on
+var finder = new ScreenLogic.FindUnits();
+finder.on('serverFound', function(server) {
+  finder.close();
+  connect(new ScreenLogic.UnitConnection(server));
+});
+
+finder.search();
+
+// use this if you want to use a direct connection to a known unit
+// connect(new ScreenLogic.UnitConnection(80, '10.0.0.85'));
+
+// use this to remote connect to a system by name (going through the Pentair servers)
+// const systemName = 'Pentair: xx-xx-xx';
+// const password = '1234';
+
+// var remote = new ScreenLogic.RemoteLogin(systemName);
+// remote.on('gatewayFound', function(unit) {
+//   remote.close();
+//   if (unit && unit.gatewayFound) {
+//     console.log('unit ' + remote.systemName + ' found at ' + unit.ipAddr + ':' + unit.port);
+//     connect(new ScreenLogic.UnitConnection(unit.port, unit.ipAddr, password));
+//   } else {
+//     console.log('no unit found by that name');
+//   }
+// });
+
+// remote.connect();
+
+// generic connection method used by all above examples
+function connect(client) {
+  client.on('loggedIn', function() {
+    this.getVersion();
+  }).on('version', function(version) {
+    this.setHeatMode(0, 0, 0);
+    console.log(' version=' + version.version);
+  }).on('heatModeChanged', function() {
+    client.close();
+  }).on('loginFailed', function() {
+    console.log(' unable to login (wrong password?)');
+    client.close();
+  });
+
+  client.connect();
+}

--- a/heatmodetest.js
+++ b/heatmodetest.js
@@ -36,7 +36,7 @@ function connect(client) {
   client.on('loggedIn', function() {
     this.getVersion();
   }).on('version', function(version) {
-    this.setHeatMode(0, 0, 0);
+    this.setHeatMode(0, 0, 3);
     console.log(' version=' + version.version);
   }).on('heatModeChanged', function() {
     client.close();

--- a/index.js
+++ b/index.js
@@ -210,6 +210,10 @@ class UnitConnection extends EventEmitter {
     this.client.write(new messages.SLSetHeatSetPointMessage(controllerId, bodyType, temperature).toBuffer());
   }
 
+  setHeatMode(controllerId, bodyType, heatMode) {
+    this.client.write(new messages.SLSetHeatModeMessage(controllerId, bodyType, heatMode).toBuffer());
+  }
+
   sendLightCommand(controllerId, command) {
     this.client.write(new messages.SLLightControlMessage(controllerId, command).toBuffer());
   }
@@ -258,6 +262,10 @@ class UnitConnection extends EventEmitter {
       case messages.SLSetHeatSetPointMessage.getResponseId():
         // console.log("  it's a setpoint ack");
         this.emit('setPointChanged', new messages.SLSetHeatSetPointMessage());
+        break;
+      case messages.SLSetHeatModeMessage.getResponseId():
+        // console.log("  it's a heater mode ack");
+        this.emit('heatModeChanged', new messages.SLSetHeatModeMessage());
         break;
       case messages.SLLightControlMessage.getResponseId():
         // console.log("  it's a light control ack");

--- a/messages/SLSetHeatMode.js
+++ b/messages/SLSetHeatMode.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const SLMessage = require('./SLMessage.js').SLMessage;
+
+const MSG_ID = 12538;
+
+exports.SLSetHeatMode = class SLSetHeatMode extends SLMessage {
+  constructor(controllerIndex, bodyType, heatMode) {
+    super(0, MSG_ID);
+
+    this.controllerIndex = controllerIndex;
+    this.bodyType = bodyType;
+    this.heatMode = heatMode;
+    // heatmodes:
+    // 0: "Off", 1: "Solar", 2 : "Solar Preferred", 3 : "Heat Pump", 4: "Don't Change"
+  }
+
+  encode() {
+    this.writeInt32LE(this.controllerIndex || 0);
+    this.writeInt32LE(this.bodyType || 0);
+    this.writeInt32LE(this.heatMode || 0);
+
+    super.encode();
+  }
+
+  static getResponseId() {
+    return MSG_ID + 1;
+  }
+};

--- a/messages/index.js
+++ b/messages/index.js
@@ -10,4 +10,5 @@ exports.SLVersionMessage = require('./SLVersionMessage.js').SLVersionMessage;
 exports.SLSetCircuitStateMessage = require('./SLSetCircuitStateMessage.js').SLSetCircuitStateMessage;
 exports.SLGetGatewayDataMessage = require('./SLGetGatewayDataMessage.js').SLGetGatewayDataMessage;
 exports.SLSetHeatSetPointMessage = require('./SLSetHeatSetPoint.js').SLSetHeatSetPoint;
+exports.SLSetHeatModeMessage = require('./SLSetHeatMode.js').SLSetHeatMode;
 exports.SLLightControlMessage = require('./SLLightControl.js').SLLightControl;


### PR DESCRIPTION
I saw the functions to set the heater Set Point, but there wasn't any functionality to actually turn set the heater modes. This PR implements this functionality, so now you can set heat point and actually set the heater to the desired mode.

The file `heatmodetest.js` is just a quick test of the functionality with my system, which I've proved works both with software and by walking out to my equipment pad. :-) I left it in for testing, but I am happy to remove it prior to merging.

README.md also updated to reflect the new functionality.