### PR TITLE
BugFix: gatewayName message.toString() conversion was stripping final character

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class FindUnits extends EventEmitter {
         port: message.readInt16LE(8),
         gatewayType: message.readUInt8(10),
         gatewaySubtype: message.readUInt8(11),
-        gatewayName: message.toString('utf8', 12, 28),
+        gatewayName: message.toString('utf8', 12, 29),
       };
 
       // console.log('  type: ' + server.type + ', host: ' + server.address + ':' + server.port + ',


### PR DESCRIPTION
Found a small bug with gatewayName, I noticed it was stripping the final character.
Increased the range from 28 to 29 and it fixed the issue.

@parnic 
