### PR TITLE
Added SLAddClient / SLRemoveClient messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,15 @@ Sets flow setting for a pump/circuit combination. See [`SLSetPumpFlow`](#slsetpu
 
 Cancels any delays on the system. See [`SLCancelDelay`](#slcanceldelay) documentation. Emits the `cancelDelay` event when response is acknowledged.
 
+### addClien()
+
+Registers to receive updates from controller when something changes. Emits the `poolStatus` event when something changes on the controller.
+
+### removeClient()
+
+No longer receive `poolStatus` messages from controller.
+
+
 ### Events
 
 * `loggedIn` - Indicates that a connection to the server has been established and the login process completed. `get` methods can be called once this event has been emitted.
@@ -643,3 +652,11 @@ Passed as an argument to the emitted `setPumpFlow` event. The passed version is 
 ## SLCancelDelay
 
 Passed as an argument to the emitted `cancelDelay` event. The passed version is empty, however, since the response is just an acknowledgement of receipt of the set command.
+
+## SLAddClient
+
+Passed as an argument to the emitted `addClient` event. The passed version is empty, however, since the response is just an acknowledgement of receipt of the command.
+
+## SLRemoveClient
+
+Passed as an argument to the emitted `removeClient` event. The passed version is empty, however, since the response is just an acknowledgement of receipt of the command.

--- a/index.js
+++ b/index.js
@@ -286,6 +286,16 @@ class UnitConnection extends EventEmitter {
     this.client.write(new messages.SLCancelDelay().toBuffer());
   }
 
+  addClient() {
+    debugUnit('sending add client command...');
+    this.client.write(new messages.SLAddClient().toBuffer());
+  }
+
+  removeClient() {
+    debugUnit('sending remove client command...');
+    this.client.write(new messages.SLRemoveClient().toBuffer());
+  }
+
   onClientMessage(msg) {
     debugUnit('received message of length %d', msg.length);
     if (msg.length < 4) {
@@ -378,6 +388,18 @@ class UnitConnection extends EventEmitter {
       case messages.SLCancelDelay.getResponseId():
         debugUnit("  it's a cancel delay ack");
         this.emit('cancelDelay', new messages.SLCancelDelay());
+        break;
+      case messages.SLAddClient.getResponseId():
+        debugUnit("  it's an add client ack");
+        this.emit('addClient', new messages.SLCancelDelay());
+        break;
+      case messages.SLRemoveClient.getResponseId():
+        debugUnit("  it's a remove client ack");
+        this.emit('removeClient', new messages.SLCancelDelay());
+        break;
+      case 12500: // This is the message received when you are registered as a client, the data is the same as a pool status message
+        debugUnit("  it's pool status");
+        this.emit('poolStatus', new messages.SLPoolStatusMessage(msg));
         break;
       case 13:
         debugUnit("  it's a login failure.");

--- a/messages/SLAddClient.js
+++ b/messages/SLAddClient.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const SLMessage = require('./SLMessage.js').SLMessage;
+
+const MSG_ID = 12522;
+
+exports.SLAddClient = class SLAddClient extends SLMessage {
+  constructor() {
+    super(0, MSG_ID);
+
+  }
+
+  encode() {
+    this.writeInt32LE(0);
+    this.writeInt32LE(9001); // This is supposed to be a random number, i guess to identify clients, but i dont see how it makes a difference
+
+    super.encode();
+  }
+
+  static getResponseId() {
+    return MSG_ID + 1;
+  }
+};

--- a/messages/SLRemoveClient.js
+++ b/messages/SLRemoveClient.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const SLMessage = require('./SLMessage.js').SLMessage;
+
+const MSG_ID = 12524;
+
+exports.SLRemoveClient = class SLRemoveClient extends SLMessage {
+  constructor() {
+    super(0, MSG_ID);
+
+  }
+
+  encode() {
+    this.writeInt32LE(0);
+    this.writeInt32LE(9001); // This is supposed to be a random number, i guess to identify clients, but i dont see how it makes a difference
+
+    super.encode();
+  }
+
+  static getResponseId() {
+    return MSG_ID + 1;
+  }
+};

--- a/messages/index.js
+++ b/messages/index.js
@@ -23,3 +23,5 @@ exports.SLSetCircuitRuntimeById = require('./SLSetCircuitRuntimeById.js').SLSetC
 exports.SLGetPumpStatus = require('./SLGetPumpStatus.js').SLGetPumpStatus;
 exports.SLSetPumpFlow = require('./SLSetPumpFlow.js').SLSetPumpFlow;
 exports.SLCancelDelay = require('./SLCancelDelay.js').SLCancelDelay;
+exports.SLAddClient = require('./SLAddClient.js').SLAddClient;
+exports.SLRemoveClient = require('./SLRemoveClient.js').SLRemoveClient;


### PR DESCRIPTION
This add the above messages, allows you to register to receive poolStatus updates as things change (pumps running, lights changed, etc ) this way you dont have to poll for changes.  This mimics the way the Android/Windows apps are able to update the UI quickly when something gets updated.

In the original code a random number is generated as the senderId, but i just made it a fixed number for now, if we were to use a random number we would have to keep track of the number so we can unregister later.