### PR TITLE
Remove Duplicate Test Case - SLMessage

### DIFF
--- a/test/slmessage.spec.js
+++ b/test/slmessage.spec.js
@@ -54,16 +54,6 @@ describe('SLMessage utilities', function() {
       assert.strictEqual(decodedMsg.action, 0);
       assert.strictEqual(decodedMsg.dataLength, 0);
     }
-
-    {
-      let msg = new SLMessage.Outbound();
-      msg.createBaseMessage();
-      let decodedMsg = new SLMessage.Inbound();
-      decodedMsg.readFromBuffer(msg.toBuffer());
-      assert.strictEqual(decodedMsg.senderId, 0);
-      assert.strictEqual(decodedMsg.action, 0);
-      assert.strictEqual(decodedMsg.dataLength, 0);
-    }
   });
 
   it('encodes and decodes SLStrings', function() {


### PR DESCRIPTION
### Removed Duplicate Test Case

- Removed a duplicate test case that was running twice.
- Verified all tests pass successfully without the duplicate.
- Please review and merge.